### PR TITLE
feat: add get_connector_manifest command to retrieve connector metadata

### DIFF
--- a/connector_builder_mcp/_connector_builder.py
+++ b/connector_builder_mcp/_connector_builder.py
@@ -29,6 +29,9 @@ from pydantic import BaseModel, Field
 from connector_builder_mcp._secrets import hydrate_config, register_secrets_tools
 from connector_builder_mcp._util import validate_manifest_structure
 
+_REGISTRY_URL = "https://connectors.airbyte.com/files/registries/v0/oss_registry.json"
+_MANIFEST_ONLY_LANGUAGE = "manifest-only"
+
 logger = logging.getLogger(__name__)
 
 
@@ -452,6 +455,44 @@ def _get_topic_specific_docs(topic: str) -> str:
         return f"# {topic} Documentation\n\nUnable to fetch detailed documentation from GitHub. Please refer to the full reference: {docs_url}\n\nError: {str(e)}"
 
 
+def _is_manifest_only_connector(connector_name: str) -> bool:
+    """Check if a connector is manifest-only by querying the registry.
+
+    Args:
+        connector_name: Name of the connector (e.g., 'source-faker')
+
+    Returns:
+        True if the connector is manifest-only, False otherwise or on error
+    """
+    try:
+        response = requests.get(_REGISTRY_URL, timeout=30)
+        response.raise_for_status()
+        registry_data = response.json()
+
+        for connector_list in [
+            registry_data.get("sources", []),
+            registry_data.get("destinations", []),
+        ]:
+            for connector in connector_list:
+                docker_repo = connector.get("dockerRepository", "")
+                repo_connector_name = docker_repo.replace("airbyte/", "")
+
+                if repo_connector_name == connector_name:
+                    language = connector.get("language")
+                    tags = connector.get("tags", [])
+
+                    return (
+                        language == _MANIFEST_ONLY_LANGUAGE
+                        or f"language:{_MANIFEST_ONLY_LANGUAGE}" in tags
+                    )
+
+        return False
+
+    except Exception as e:
+        logger.warning(f"Failed to fetch registry data for {connector_name}: {e}")
+        return False
+
+
 def get_connector_manifest(
     connector_name: Annotated[
         str,
@@ -477,7 +518,14 @@ def get_connector_manifest(
 
     cleaned_version = version.removeprefix("v")
 
-    manifest_url = f"https://connectors.airbyte.com/metadata/airbyte/{connector_name}/{cleaned_version}/metadata.yaml"
+    is_manifest_only = _is_manifest_only_connector(connector_name)
+    file_type = "manifest.yaml" if is_manifest_only else "metadata.yaml"
+
+    logger.info(
+        f"Connector {connector_name} is {'manifest-only' if is_manifest_only else 'not manifest-only'}, fetching {file_type}"
+    )
+
+    manifest_url = f"https://connectors.airbyte.com/metadata/airbyte/{connector_name}/{cleaned_version}/{file_type}"
 
     try:
         response = requests.get(manifest_url, timeout=30)
@@ -486,8 +534,8 @@ def get_connector_manifest(
         return response.text
 
     except Exception as e:
-        logger.error(f"Error fetching connector manifest for {connector_name}: {e}")
-        return f"# Error fetching connector manifest\n\nUnable to fetch manifest for connector '{connector_name}' version '{version}' from {manifest_url}\n\nError: {str(e)}"
+        logger.error(f"Error fetching connector {file_type} for {connector_name}: {e}")
+        return f"# Error fetching connector {file_type}\n\nUnable to fetch {file_type} for connector '{connector_name}' version '{version}' from {manifest_url}\n\nError: {str(e)}"
 
 
 def register_connector_builder_tools(app: FastMCP) -> None:


### PR DESCRIPTION
# feat: add get_connector_manifest command to retrieve connector metadata

## Summary

This PR adds a new MCP tool `get_connector_manifest` to the connector-builder-mcp project that allows retrieval of connector metadata YAML files from the `connectors.airbyte.com` endpoint. The function accepts a connector name (required) and version (optional, defaults to 'latest') and returns the raw metadata content as a string.

**Key implementation details:**
- Uses the URL pattern: `https://connectors.airbyte.com/metadata/airbyte/{connector_name}/{version}/metadata.yaml`
- Supports version prefix cleaning (removes 'v' if present)
- Includes proper HTTP error handling and timeout (30s)
- Follows existing code patterns for tool registration and HTTP requests
- Returns descriptive error messages for failed requests

**Note**: The function name suggests it returns "manifest" files, but it actually fetches "metadata.yaml" files from the connectors.airbyte.com endpoint structure.

## Review & Testing Checklist for Human
- [ ] **Test with multiple connector types**: Verify the URL pattern works for both source and destination connectors (e.g., `source-github`, `destination-postgres`) 
- [ ] **Test version handling**: Try with specific versions, 'latest', and versions with 'v' prefix to ensure proper handling
- [ ] **Verify returned content utility**: Check that the returned metadata.yaml content contains useful information for connector building workflows
- [ ] **Test error scenarios**: Try with invalid connector names, network issues, and non-existent versions to ensure graceful error handling
- [ ] **Consider function naming**: Evaluate if `get_connector_manifest` is the appropriate name given it returns metadata.yaml files, not traditional manifest.yaml files

**Recommended test plan:**
1. Test the new tool via MCP client with known connectors like `source-faker`, `destination-postgres`
2. Verify content format and usefulness for connector development workflows
3. Test edge cases: invalid names, network failures, malformed versions

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    Server["connector_builder_mcp/server.py"]:::context
    ConnectorBuilder["connector_builder_mcp/_connector_builder.py"]:::major-edit
    FastMCP["FastMCP App"]:::context
    ExternalAPI["connectors.airbyte.com"]:::context
    
    Server --> |registers tools| FastMCP
    ConnectorBuilder --> |register_connector_builder_tools| FastMCP
    ConnectorBuilder --> |HTTP GET requests| ExternalAPI
    
    subgraph "New Function"
        GetManifest["get_connector_manifest()"]:::major-edit
    end
    
    ConnectorBuilder --> GetManifest
    GetManifest --> |"GET /metadata/airbyte/{name}/{version}/metadata.yaml"| ExternalAPI
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes


- **URL Pattern Discovery**: During development, I initially used an incorrect URL pattern (`files/metadata/airbyte/...`) and had to correct it to `metadata/airbyte/...` after investigating the actual connectors.airbyte.com bucket structure
- **Limited Testing**: Only tested with `destination-amazon-sqs` during development - broader testing across connector types is needed
- **Function vs File Naming**: There's a semantic mismatch where the function is named `get_connector_manifest` but fetches `metadata.yaml` files rather than traditional `manifest.yaml` files

**Link to Devin run**: https://app.devin.ai/sessions/050f37720b8f485a86ad1fbe51d5e013  
**Requested by**: AJ Steers (@aaronsteers)