### PR TITLE
feat!: rename find_connectors_by_feature to find_connectors_by_class_name

### DIFF
--- a/connector_builder_mcp/_connector_builder.py
+++ b/connector_builder_mcp/_connector_builder.py
@@ -836,7 +836,7 @@ def get_manifest_yaml_json_schema() -> str:
     )  # pragma: no cover # This line should not be reached
 
 
-def find_connectors_by_feature(features: str) -> list[str]:
+def find_connectors_by_class_name(class_names: str) -> list[str]:
     """Find connectors that use ALL specified class names/components.
 
     This tool searches for connectors that implement specific declarative component classes,
@@ -851,18 +851,18 @@ def find_connectors_by_feature(features: str) -> list[str]:
     - ApiKeyAuthenticator (for API key authentication)
 
     Args:
-        features: Comma-separated string of exact class names to search for.
-                 Use class names like "DynamicDeclarativeStream", not feature 
-                 descriptions like "dynamic streams" or "pagination".
+        class_names: Comma-separated string of exact class names to search for.
+                    Use class names like "DynamicDeclarativeStream", not feature
+                    descriptions like "dynamic streams" or "pagination".
 
     Returns:
         List of connector names that use ALL specified class names
     """
-    if not features.strip():
+    if not class_names.strip():
         return []
 
-    feature_list = [f.strip() for f in features.split(",") if f.strip()]
-    if not feature_list:
+    class_name_list = [f.strip() for f in class_names.split(",") if f.strip()]
+    if not class_name_list:
         return []
 
     csv_path = Path(__file__).parent / "resources" / "generated" / "connector-feature-index.csv"
@@ -884,16 +884,16 @@ def find_connectors_by_feature(features: str) -> list[str]:
 
     result_connectors = None
 
-    for feature in feature_list:
-        if feature not in feature_to_connectors:
+    for class_name in class_name_list:
+        if class_name not in feature_to_connectors:
             return []
 
-        connectors_with_feature = feature_to_connectors[feature]
+        connectors_with_class = feature_to_connectors[class_name]
 
         if result_connectors is None:
-            result_connectors = connectors_with_feature.copy()
+            result_connectors = connectors_with_class.copy()
         else:
-            result_connectors = result_connectors.intersection(connectors_with_feature)
+            result_connectors = result_connectors.intersection(connectors_with_class)
 
     return sorted(result_connectors) if result_connectors else []
 
@@ -912,5 +912,5 @@ def register_connector_builder_tools(app: FastMCP) -> None:
     app.tool(get_connector_builder_checklist)
     app.tool(get_connector_builder_docs)
     app.tool(get_connector_manifest)
-    app.tool(find_connectors_by_feature)
+    app.tool(find_connectors_by_class_name)
     register_secrets_tools(app)

--- a/connector_builder_mcp/_connector_builder.py
+++ b/connector_builder_mcp/_connector_builder.py
@@ -837,13 +837,26 @@ def get_manifest_yaml_json_schema() -> str:
 
 
 def find_connectors_by_feature(features: str) -> list[str]:
-    """Find connectors that use ALL specified features.
+    """Find connectors that use ALL specified class names/components.
+
+    This tool searches for connectors that implement specific declarative component classes,
+    not high-level feature descriptions. It expects exact class names as they appear in
+    connector manifests and the CDK.
+
+    Examples of valid class names:
+    - DynamicDeclarativeStream (for dynamic stream discovery)
+    - HttpComponentsResolver (for HTTP-based component resolution)
+    - ConfigComponentsResolver (for config-based component resolution)
+    - OAuthAuthenticator (for OAuth authentication)
+    - ApiKeyAuthenticator (for API key authentication)
 
     Args:
-        features: Comma-separated string of feature names to search for
+        features: Comma-separated string of exact class names to search for.
+                 Use class names like "DynamicDeclarativeStream", not feature 
+                 descriptions like "dynamic streams" or "pagination".
 
     Returns:
-        List of connector names that use ALL specified features
+        List of connector names that use ALL specified class names
     """
     if not features.strip():
         return []

--- a/connector_builder_mcp/_connector_builder.py
+++ b/connector_builder_mcp/_connector_builder.py
@@ -839,9 +839,7 @@ def get_manifest_yaml_json_schema() -> str:
 def find_connectors_by_class_name(class_names: str) -> list[str]:
     """Find connectors that use ALL specified class names/components.
 
-    This tool searches for connectors that implement specific declarative component classes,
-    not high-level feature descriptions. It expects exact class names as they appear in
-    connector manifests and the CDK.
+    This tool searches for connectors that implement specific declarative component classes.
 
     Examples of valid class names:
     - DynamicDeclarativeStream (for dynamic stream discovery)


### PR DESCRIPTION
# feat!: rename find_connectors_by_feature to find_connectors_by_class_name

## Summary

This PR renames the `find_connectors_by_feature` function to `find_connectors_by_class_name` and significantly improves its documentation to clarify expectations. The original function name and parameter (`features`) were misleading, as the tool actually expects exact class names from the Airbyte declarative component system, not high-level feature descriptions.

**Key Changes:**
- **BREAKING**: Renamed function from `find_connectors_by_feature` to `find_connectors_by_class_name`
- **BREAKING**: Renamed parameter from `features` to `class_names`
- Updated all internal variable names for consistency (`feature_list` → `class_name_list`, etc.)
- Enhanced documentation with clear examples of valid class names
- Added explicit clarification that it expects class names like "DynamicDeclarativeStream", not feature descriptions like "dynamic streams" or "pagination"

The function behavior is unchanged - it still searches a CSV index file and returns connectors that use ALL specified class names.

## Review & Testing Checklist for Human

- [ ] **Test the renamed function works correctly** by calling it with known class names (e.g., "DynamicDeclarativeStream", "HttpComponentsResolver")
- [ ] **Verify the CSV index file structure** contains the class names mentioned in the documentation examples
- [ ] **Test MCP tool exposure** - confirm the renamed tool appears correctly when listing MCP tools and can be invoked
- [ ] **Check for any missed references** to the old function name across the entire codebase (I searched but double-check is valuable)
- [ ] **Validate documentation examples** - ensure the class name examples provided are accurate and representative of what's actually available in the system

**Recommended Test Plan:**
1. Start the MCP server and list tools to confirm `find_connectors_by_class_name` appears
2. Test with known working class names: `DynamicDeclarativeStream`, `HttpComponentsResolver`, `ConfigComponentsResolver`
3. Verify the tool returns expected connector lists (should match previous behavior)
4. Test with invalid class names to ensure proper error handling

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    CSV["resources/generated/<br/>connector-feature-index.csv"]:::context
    Main["_connector_builder.py"]:::major-edit
    Server["server.py"]:::context
    MCP["MCP Tool Registration"]:::minor-edit
    
    CSV --> Main
    Main --> Server
    Server --> MCP
    
    Main --> |"find_connectors_by_class_name()<br/>(renamed from find_connectors_by_feature)"| Function["Function Implementation"]:::major-edit
    Function --> |"class_names parameter<br/>(renamed from features)"| Params["Parameter Handling"]:::major-edit
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit
        L3["Context/No Edit"]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- This change was requested by AJ Steers (@aaronsteers) to clarify the tool's expectations
- Session URL: https://app.devin.ai/sessions/038108fef7da4d1392c78e3fa20d7e9a
- The function was successfully tested with class names like `DynamicDeclarativeStream` during development
- All tests pass (63 passed, 2 skipped) confirming no regressions
- Breaking changes are acceptable per user confirmation, so semantic versioning will handle the major version bump

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._