### PR TITLE
feat: make populate_dotenv_missing_secrets_stubs require absolute paths and non-destructive

### DIFF
--- a/connector_builder_mcp/_secrets.py
+++ b/connector_builder_mcp/_secrets.py
@@ -133,7 +133,9 @@ def list_dotenv_secrets(
 
 
 def populate_dotenv_missing_secrets_stubs(
-    dotenv_path: Annotated[str, Field(description="Absolute path to the .env file to add secrets to")],
+    dotenv_path: Annotated[
+        str, Field(description="Absolute path to the .env file to add secrets to")
+    ],
     manifest: Annotated[
         str | None,
         Field(
@@ -212,7 +214,9 @@ def populate_dotenv_missing_secrets_stubs(
                 )
 
             collision_list = ", ".join(collisions)
-            existing_secrets_summary = [f'{s.key}({"set" if s.is_set else "unset"})' for s in secrets_info]
+            existing_secrets_summary = [
+                f"{s.key}({'set' if s.is_set else 'unset'})" for s in secrets_info
+            ]
             return f"Error: Cannot create stubs for secrets that already exist: {collision_list}. Existing secrets in file: {existing_secrets_summary}"
 
         added_count = 0

--- a/connector_builder_mcp/_secrets.py
+++ b/connector_builder_mcp/_secrets.py
@@ -217,7 +217,7 @@ def populate_dotenv_missing_secrets_stubs(
             existing_secrets_summary = [
                 f"{s.key}({'set' if s.is_set else 'unset'})" for s in secrets_info
             ]
-            return f"Error: Cannot create stubs for secrets that already exist: {collision_list}. Existing secrets in file: {existing_secrets_summary}"
+            return f"Error: Cannot create stubs for secrets that already exist: {collision_list}. Existing secrets in file: {', '.join(existing_secrets_summary)}"
 
         added_count = 0
         for dotenv_key in secrets_to_add:

--- a/connector_builder_mcp/_secrets.py
+++ b/connector_builder_mcp/_secrets.py
@@ -133,7 +133,7 @@ def list_dotenv_secrets(
 
 
 def populate_dotenv_missing_secrets_stubs(
-    dotenv_path: Annotated[str, Field(description="Path to the .env file to add secrets to")],
+    dotenv_path: Annotated[str, Field(description="Absolute path to the .env file to add secrets to")],
     manifest: Annotated[
         str | None,
         Field(
@@ -157,18 +157,26 @@ def populate_dotenv_missing_secrets_stubs(
 
     If both are provided, both sets of secrets will be added.
 
+    This function is non-destructive and will not overwrite existing secrets.
+    If any of the secrets to be added already exist, an error will be returned
+    with information about the existing secrets.
+
     Returns:
         Message about the operation result
     """
+    path_obj = Path(dotenv_path)
+    if not path_obj.is_absolute():
+        return f"Error: Path must be absolute, got relative path: {dotenv_path}"
+
     config_paths_list = config_paths.split(",") if config_paths else []
     if not any([manifest, config_paths_list]):
         return "Error: Must provide either manifest or config_paths"
 
     try:
         if allow_create:
-            Path(dotenv_path).parent.mkdir(parents=True, exist_ok=True)
-            Path(dotenv_path).touch()
-        elif not Path(dotenv_path).exists():
+            path_obj.parent.mkdir(parents=True, exist_ok=True)
+            path_obj.touch()
+        elif not path_obj.exists():
             return f"Error: File {dotenv_path} does not exist and allow_create=False"
 
         secrets_to_add = []
@@ -184,6 +192,28 @@ def populate_dotenv_missing_secrets_stubs(
 
         if not secrets_to_add:
             return "No secrets found to add"
+
+        existing_secrets = {}
+        if path_obj.exists():
+            try:
+                existing_secrets = dotenv_values(dotenv_path) or {}
+            except Exception as e:
+                logger.error(f"Error reading existing secrets: {e}")
+
+        collisions = [key for key in secrets_to_add if key in existing_secrets]
+        if collisions:
+            secrets_info = []
+            for key, value in existing_secrets.items():
+                secrets_info.append(
+                    SecretInfo(
+                        key=key,
+                        is_set=bool(value and value.strip() and not value.strip().startswith("#")),
+                    )
+                )
+
+            collision_list = ", ".join(collisions)
+            existing_secrets_summary = [f'{s.key}({"set" if s.is_set else "unset"})' for s in secrets_info]
+            return f"Error: Cannot create stubs for secrets that already exist: {collision_list}. Existing secrets in file: {existing_secrets_summary}"
 
         added_count = 0
         for dotenv_key in secrets_to_add:


### PR DESCRIPTION
# feat: make populate_dotenv_missing_secrets_stubs require absolute paths and non-destructive

## Summary

This PR updates the `populate_dotenv_missing_secrets_stubs` function to address two critical issues:

1. **Absolute path requirement**: The function now validates that the provided `dotenv_path` is absolute using `Path.is_absolute()` and rejects relative paths with a clear error message. This prevents ambiguity about the caller's working directory context.

2. **Non-destructive behavior**: The function now checks for existing secrets before writing and throws an error if any collisions are detected, rather than silently overwriting existing values. When collisions occur, it returns a detailed error message listing all existing secrets and their set/unset status.

### Key Changes
- Added absolute path validation at function start
- Implemented collision detection using `dotenv_values()` to read existing secrets
- Enhanced error responses to include existing secrets information following the `SecretInfo` model pattern
- Updated function documentation to clarify the new non-destructive behavior
- Updated all existing tests to use absolute paths (breaking change)
- Added comprehensive test coverage for new validation and collision detection features

## Review & Testing Checklist for Human

⚠️ **This is a breaking API change** - all callers must now provide absolute paths

- [ ] **Verify absolute path validation works correctly** across different platforms and edge cases (test with various relative path formats)
- [ ] **Test collision detection logic** with different dotenv file contents (empty values, comment stubs, real secrets, malformed entries)
- [ ] **Confirm backward compatibility** - verify that existing integrations can handle the new absolute path requirement
- [ ] **Validate error message format** - ensure the collision error response format is consumable by calling code and matches expected patterns
- [ ] **Test edge cases** - empty files, permission errors, malformed dotenv files, concurrent access scenarios

**Recommended test plan**: Create a test dotenv file with mixed content (real secrets, empty values, comment stubs) and verify the function correctly identifies collisions and preserves existing content.

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

    A["connector_builder_mcp/_secrets.py"]:::major-edit
    B["tests/test_secrets.py"]:::major-edit
    C["populate_dotenv_missing_secrets_stubs()"]:::major-edit
    D["list_dotenv_secrets()"]:::context
    E["SecretInfo model"]:::context
    F["dotenv_values()"]:::context

    A --> C
    A --> D
    A --> E
    B --> C
    C --> F
    D --> E
    C --> E

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#ADD8E6  
    classDef context fill:#FFFFFF
```

### Notes

- The collision detection logic reuses the existing `dotenv_values()` pattern from `list_dotenv_secrets()` for consistency
- Secret "set" status determination includes checking if values are non-empty, non-whitespace, and don't start with "#" (comment stubs)
- All 66 tests pass including the new test cases for absolute path validation and collision detection
- This change was requested by AJ Steers (@aaronsteers) to improve the security and reliability of the secrets management functionality

**Link to Devin run**: https://app.devin.ai/sessions/a1ddcae2e2cc41dd9da9121d4b034e32  
**Requested by**: @aaronsteers

> [!IMPORTANT]
> **Auto-merge enabled.**
> 
> _This PR is set to merge automatically when all requirements are met._