### PR TITLE
feat: integrate CDK preprocessing into MCP validation

### DIFF
--- a/connector_builder_mcp/_connector_builder.py
+++ b/connector_builder_mcp/_connector_builder.py
@@ -34,6 +34,12 @@ from airbyte_cdk.models import (
     DestinationSyncMode,
     SyncMode,
 )
+from airbyte_cdk.sources.declarative.parsers.manifest_reference_resolver import (
+    ManifestReferenceResolver,
+)
+from airbyte_cdk.sources.declarative.parsers.manifest_component_transformer import (
+    ManifestComponentTransformer,
+)
 
 from connector_builder_mcp._guidance import CONNECTOR_BUILDER_CHECKLIST, TOPIC_MAPPING
 from connector_builder_mcp._secrets import hydrate_config, register_secrets_tools
@@ -218,7 +224,26 @@ def validate_manifest(
         manifest_dict = parse_manifest_input(manifest)
 
         if not validate_manifest_structure(manifest_dict):
-            errors.append("Manifest missing required fields: version, type, check, streams")
+            errors.append("Manifest missing required fields: version, type, check, and either streams or dynamic_streams")
+            return ManifestValidationResult(is_valid=False, errors=errors, warnings=warnings)
+
+        try:
+            logger.info("Applying CDK preprocessing: resolving references")
+            reference_resolver = ManifestReferenceResolver()
+            resolved_manifest = reference_resolver.preprocess_manifest(manifest_dict)
+            
+            logger.info("Applying CDK preprocessing: propagating types and parameters")
+            component_transformer = ManifestComponentTransformer()
+            processed_manifest = component_transformer.propagate_types_and_parameters(
+                "", resolved_manifest, {}
+            )
+            
+            logger.info("CDK preprocessing completed successfully")
+            manifest_dict = processed_manifest
+            
+        except Exception as preprocessing_error:
+            logger.error(f"CDK preprocessing failed: {preprocessing_error}")
+            errors.append(f"Preprocessing error: {str(preprocessing_error)}")
             return ManifestValidationResult(is_valid=False, errors=errors, warnings=warnings)
 
         try:

--- a/connector_builder_mcp/_connector_builder.py
+++ b/connector_builder_mcp/_connector_builder.py
@@ -34,11 +34,11 @@ from airbyte_cdk.models import (
     DestinationSyncMode,
     SyncMode,
 )
-from airbyte_cdk.sources.declarative.parsers.manifest_reference_resolver import (
-    ManifestReferenceResolver,
-)
 from airbyte_cdk.sources.declarative.parsers.manifest_component_transformer import (
     ManifestComponentTransformer,
+)
+from airbyte_cdk.sources.declarative.parsers.manifest_reference_resolver import (
+    ManifestReferenceResolver,
 )
 
 from connector_builder_mcp._guidance import CONNECTOR_BUILDER_CHECKLIST, TOPIC_MAPPING
@@ -224,23 +224,25 @@ def validate_manifest(
         manifest_dict = parse_manifest_input(manifest)
 
         if not validate_manifest_structure(manifest_dict):
-            errors.append("Manifest missing required fields: version, type, check, and either streams or dynamic_streams")
+            errors.append(
+                "Manifest missing required fields: version, type, check, and either streams or dynamic_streams"
+            )
             return ManifestValidationResult(is_valid=False, errors=errors, warnings=warnings)
 
         try:
             logger.info("Applying CDK preprocessing: resolving references")
             reference_resolver = ManifestReferenceResolver()
             resolved_manifest = reference_resolver.preprocess_manifest(manifest_dict)
-            
+
             logger.info("Applying CDK preprocessing: propagating types and parameters")
             component_transformer = ManifestComponentTransformer()
             processed_manifest = component_transformer.propagate_types_and_parameters(
                 "", resolved_manifest, {}
             )
-            
+
             logger.info("CDK preprocessing completed successfully")
             manifest_dict = processed_manifest
-            
+
         except Exception as preprocessing_error:
             logger.error(f"CDK preprocessing failed: {preprocessing_error}")
             errors.append(f"Preprocessing error: {str(preprocessing_error)}")

--- a/connector_builder_mcp/_util.py
+++ b/connector_builder_mcp/_util.py
@@ -110,5 +110,9 @@ def validate_manifest_structure(manifest: dict[str, Any]) -> bool:
     Returns:
         True if manifest has required structure, False otherwise
     """
-    required_fields = ["version", "type", "check", "streams"]
-    return all(field in manifest for field in required_fields)
+    required_fields = ["version", "type", "check"]
+    has_required = all(field in manifest for field in required_fields)
+    
+    has_streams = "streams" in manifest or "dynamic_streams" in manifest
+    
+    return has_required and has_streams

--- a/connector_builder_mcp/_util.py
+++ b/connector_builder_mcp/_util.py
@@ -112,7 +112,7 @@ def validate_manifest_structure(manifest: dict[str, Any]) -> bool:
     """
     required_fields = ["version", "type", "check"]
     has_required = all(field in manifest for field in required_fields)
-    
+
     has_streams = "streams" in manifest or "dynamic_streams" in manifest
-    
+
     return has_required and has_streams


### PR DESCRIPTION
# feat: integrate CDK preprocessing into MCP validation

## Summary

This PR integrates the Airbyte CDK's manifest preprocessing steps into the connector builder MCP validation pipeline to fix validation failures for manifests that use `$ref` references and `$parameters`. 

**Problem**: The MCP validation was performing only basic JSON schema validation without the preprocessing that the CDK does internally. This caused valid manifests like `source-airtable` to fail validation because they rely on reference resolution and parameter propagation.

**Solution**: Added the same preprocessing pipeline that the CDK uses:
1. **Reference Resolution** via `ManifestReferenceResolver.preprocess_manifest()` - resolves `$ref` references in manifests
2. **Parameter Propagation** via `ManifestComponentTransformer.propagate_types_and_parameters()` - propagates `$parameters` and sets default types
3. **Updated Structure Validation** - now accepts both `streams` and `dynamic_streams` fields

**Files Changed**:
- `connector_builder_mcp/_connector_builder.py` - Added CDK imports and preprocessing pipeline
- `connector_builder_mcp/_util.py` - Updated validation to accept `dynamic_streams`

## Review & Testing Checklist for Human

**🔴 HIGH PRIORITY (3 items)**:
- [ ] **End-to-end test with source-airtable manifest** - Verify that `source-airtable` manifest now passes validation (this was the original failing case)
- [ ] **Regression testing** - Test existing manifests (rick-and-morty, simple-api) to ensure no validation regressions
- [ ] **Error handling verification** - Test manifests with malformed `$ref` or `$parameters` to ensure graceful error handling

**Test Plan**: 
1. Use MCP tool call to validate source-airtable manifest (should now pass)
2. Re-run existing manifest validation tests to ensure no regressions
3. Test edge cases with invalid references/parameters

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TB
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end
    
    MCP["MCP validate_manifest tool"]:::context
    CB["_connector_builder.py<br/>validate_manifest()"]:::major-edit
    UTIL["_util.py<br/>validate_manifest_structure()"]:::minor-edit
    
    subgraph "CDK Components (External)"
        REF["ManifestReferenceResolver<br/>preprocess_manifest()"]:::context
        TRANS["ManifestComponentTransformer<br/>propagate_types_and_parameters()"]:::context
    end
    
    SCHEMA["JSON Schema Validation"]:::context
    
    MCP --> CB
    CB --> UTIL
    CB --> REF
    CB --> TRANS
    REF --> SCHEMA
    TRANS --> SCHEMA
    
    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB  
    classDef context fill:#FFFFFF
```

### Notes

- **Session Info**: Requested by AJ Steers (@aaronsteers) - [Devin Session](https://app.devin.ai/sessions/d01c48ed8f0144139918d06f4a1b475b)
- **Testing Limitation**: Due to MCP server caching, couldn't fully test end-to-end via MCP tool calls during development, but direct function calls confirm preprocessing works correctly
- **Performance**: Added preprocessing steps may impact validation performance for complex manifests - monitor for any significant slowdowns
- **CDK Dependency**: This creates a tighter coupling with CDK internals - any CDK changes to these components could affect MCP validation