### PR TITLE
fix: add --all-extras flag to pdoc-publish workflow

### DIFF
--- a/.github/workflows/pdoc-publish.yml
+++ b/.github/workflows/pdoc-publish.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/configure-pages@v5
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --all-extras
 
       - name: Generate documentation
         run: |


### PR DESCRIPTION
# fix: add --all-extras flag to pdoc-publish workflow

## Summary

Fixed the consistently failing "Publish Docs" CI workflow by adding the missing `--all-extras` flag to the `uv sync` command. This makes the workflow configuration consistent with the working "Generate Docs" workflow and ensures all necessary dependencies are installed for documentation generation.

**Root cause**: The `pdoc-publish.yml` workflow was using `uv sync` while the working `pdoc-preview.yml` workflow uses `uv sync --all-extras`. Without the `--all-extras` flag, pdoc and other documentation dependencies weren't being installed, causing the documentation generation to fail.

**Change**: Single line modification in `.github/workflows/pdoc-publish.yml` line 43:
```diff
- run: uv sync
+ run: uv sync --all-extras
```

## Review & Testing Checklist for Human

- [ ] **Verify CI passes**: Check that the "Publish Docs" workflow now succeeds when this PR is merged to main
- [ ] **Test documentation deployment**: Confirm that docs are successfully deployed to GitHub Pages and accessible
- [ ] **Validate generated content**: Spot-check that the generated documentation looks correct and complete

**Recommended test plan**: 
1. Merge this PR and wait for the "Publish Docs" workflow to run on main branch
2. Visit the GitHub Pages URL to verify docs are deployed correctly
3. Check that the documentation content matches what's generated locally with `poe docs-generate`

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    subgraph "CI Workflows"
        preview[".github/workflows/<br/>pdoc-preview.yml"]:::context
        publish[".github/workflows/<br/>pdoc-publish.yml"]:::major-edit
    end
    
    subgraph "Documentation"
        poe["poe_tasks.toml<br/>docs-generate task"]:::context
        pdoc["pdoc command"]:::context
        output["docs/generated/<br/>output"]:::context
    end
    
    preview -->|"uv sync --all-extras<br/>(working)"| poe
    publish -->|"uv sync --all-extras<br/>(fixed)"| poe
    poe --> pdoc
    pdoc --> output
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB
classDef context fill:#FFFFFF
```

### Notes

- This fix was identified by comparing the failing `pdoc-publish.yml` with the working `pdoc-preview.yml` workflow
- Documentation generation was tested locally and works correctly with the `--all-extras` flag
- The change is minimal and follows existing patterns in the codebase
- Recent CI runs show the "Publish Docs" workflow has been failing consistently, while "Generate Docs" works fine

**Link to Devin run**: https://app.devin.ai/sessions/a6da195870d44c0f9b651a780642c2ff  
**Requested by**: @aaronsteers