### PR TITLE
chore: replace maintenance PATs with octavia-bot GitHub App authentication

### DIFF
--- a/.github/workflows/autofix-command.yml
+++ b/.github/workflows/autofix-command.yml
@@ -27,12 +27,20 @@ jobs:
     runs-on: "${{ matrix.os }}-latest"
     steps:
       # Custom steps to fetch the PR and checkout the code:
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@v2
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "connector-builder-mcp"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
       - name: Checkout Airbyte
         uses: actions/checkout@v4
         with:
           # Important that this is set so that CI checks are triggered again
           # Without this we would be forever waiting on required checks to pass
-          token: ${{ secrets.GH_PAT_APPROVINGTON_OCTAVIA }}
+          token: ${{ steps.get-app-token.outputs.token }}
 
       - name: Checkout PR (${{ github.event.inputs.pr }})
         uses: dawidd6/action-checkout-pr@v1

--- a/.github/workflows/poe-command.yml
+++ b/.github/workflows/poe-command.yml
@@ -20,9 +20,17 @@ jobs:
       GCP_GSM_CREDENTIALS: ${{ secrets.GCP_GSM_CREDENTIALS }}
     runs-on: ubuntu-latest
     steps:
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@v2
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "connector-builder-mcp"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
       - name: Run Poe Slash Command Processor
         uses: aaronsteers/poe-command-processor@v1
         with:
           pr: ${{ github.event.inputs.pr }}
           comment-id: ${{ github.event.inputs.comment-id }}
-          github-token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          github-token: ${{ steps.get-app-token.outputs.token }}

--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -8,6 +8,14 @@ jobs:
   slashCommandDispatch:
     runs-on: ubuntu-24.04
     steps:
+      - name: Authenticate as GitHub App
+        uses: actions/create-github-app-token@v2
+        id: get-app-token
+        with:
+          owner: "airbytehq"
+          repositories: "connector-builder-mcp"
+          app-id: ${{ secrets.OCTAVIA_BOT_APP_ID }}
+          private-key: ${{ secrets.OCTAVIA_BOT_PRIVATE_KEY }}
       - name: Slash Command Dispatch
         id: dispatch
         # TODO: Revert to `peter-evans/slash-command-dispatch@v4` after PR merges:
@@ -15,7 +23,7 @@ jobs:
         uses: aaronsteers/slash-command-dispatch@aj/fix/add-dispatched-bool-output
         with:
           repository: ${{ github.repository }}
-          token: ${{ secrets.GH_PAT_MAINTENANCE_OCTAVIA }}
+          token: ${{ steps.get-app-token.outputs.token }}
           dispatch-type: workflow
           issue-type: both
 


### PR DESCRIPTION
# chore: replace maintenance PATs with octavia-bot GitHub App authentication

## Summary
Replaces Personal Access Token (PAT) authentication with octavia-bot GitHub App authentication across 3 workflow files in the connector-builder-mcp repository. This standardizes authentication for PR automation workflows and removes dependency on individual maintenance PATs (`GH_PAT_MAINTENANCE_OCTAVIA`, `GH_PAT_APPROVINGTON_OCTAVIA`).

**Workflows updated:**
- `autofix-command.yml` - Auto-fix lint/format issues on PRs
- `poe-command.yml` - On-demand poe task execution  
- `slash-command-dispatch.yml` - Slash command processing for PR workflows

Each workflow now uses the standardized GitHub App token generation pattern with `actions/create-github-app-token@v2` and references the generated token via `${{ steps.get-app-token.outputs.token }}`.

## Review & Testing Checklist for Human
- [ ] **Verify octavia-bot GitHub App permissions**: Confirm the octavia-bot GitHub App has appropriate permissions for this repository (PR creation, comments, repository access)
- [ ] **Check secret configuration**: Ensure `OCTAVIA_BOT_APP_ID` and `OCTAVIA_BOT_PRIVATE_KEY` secrets are properly configured in repository settings
- [ ] **Test workflow authentication**: Trigger one of the updated workflows (e.g., `/autofix` command on a test PR) to verify the GitHub App authentication works correctly
- [ ] **Validate repository scoping**: Confirm the `repositories: "connector-builder-mcp"` parameter matches this repository's needs

### Notes
This change is part of a broader effort to replace maintenance PATs across all Airbyte repositories. The authentication pattern follows the established standard used in other repositories.

**Requested by:** @aaronsteers  
**Devin session:** https://app.devin.ai/sessions/a0a8897f6d5b4046bf1ebf8866cf1f4e