### PR TITLE
ci: Add GitHub action linting workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,25 @@
+name: GitHub action linting
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Run actionlint
+        uses: reviewdog/action-actionlint@v1.67.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          reporter: github-pr-review
+          level: error


### PR DESCRIPTION
# ci: Add GitHub action linting workflow

## Summary
Adds a new GitHub Actions workflow that runs `actionlint` (a GitHub Actions workflow linter) with `reviewdog` for PR annotations. The workflow runs conditionally only when files in `.github/workflows/**` are modified, providing automated linting feedback directly on pull requests through line-by-line comments.

Key features:
- **Conditional execution**: Only runs when workflow files are changed using `paths` filters
- **PR annotations**: Uses reviewdog's `github-pr-review` reporter for direct PR comment feedback
- **actionlint integration**: Leverages actionlint for comprehensive workflow file validation including syntax, type checking, and security analysis

## Review & Testing Checklist for Human
- [ ] **Test conditional triggering**: Modify a workflow file in a test PR and verify this workflow runs automatically
- [ ] **Verify PR annotations work**: Introduce an intentional error in a workflow file and confirm reviewdog posts PR review comments with actionlint feedback
- [ ] **Check workflow doesn't run unnecessarily**: Make changes to non-workflow files and verify this workflow doesn't trigger
- [ ] **Validate reviewdog action version**: Confirm `reviewdog/action-actionlint@v1.67.0` is the appropriate version to use

### Test Plan
1. Create a test branch with a workflow file containing actionlint violations (e.g., invalid action version, incorrect syntax)
2. Open a PR and verify the actionlint workflow runs and posts review comments
3. Make changes to Python files only and verify the workflow doesn't run
4. Test that the workflow runs on both PR events and pushes to main when workflow files change

### Notes
- This workflow complements existing linting (ruff, mypy) by adding GitHub Actions-specific validation
- Uses `level: error` to focus on critical issues rather than warnings
- Requested by @aaronsteers in Devin session: https://app.devin.ai/sessions/064c9d5b289f41539aa6e5f6acfbb8cf