### PR TITLE
feat: Add check-gh-actions poe task for actionlint CLI

### DIFF
--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -8,6 +8,7 @@ format = { cmd = "uv run ruff format .", help = "Format code with ruff" }
 format-check = { cmd = "uv run ruff format --check .", help = "Format check with ruff" }
 lint = { cmd = "uv run ruff check .", help = "Lint code with ruff" }
 lint-fix = { cmd = "uv run ruff check --fix .", help = "Lint and fix code with ruff" }
+check-gh-actions = { cmd = "actionlint", help = "Lint GitHub Actions workflows" }
 lock = { cmd = "uv lock", help = "Lock dependencies." }
 mypy = { cmd = "uv run mypy connector_builder_mcp", help = "Type check code with mypy" }
 test = { cmd = "uv run pytest tests/ -v", help = "Run tests with verbose output" }

--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -8,7 +8,7 @@ format = { cmd = "uv run ruff format .", help = "Format code with ruff" }
 format-check = { cmd = "uv run ruff format --check .", help = "Format check with ruff" }
 lint = { cmd = "uv run ruff check .", help = "Lint code with ruff" }
 lint-fix = { cmd = "uv run ruff check --fix .", help = "Lint and fix code with ruff" }
-check-gh-actions = { cmd = "actionlint", help = "Lint GitHub Actions workflows (requires: go install github.com/rhymond/actionlint/cmd/actionlint@latest)" }
+check-gh-actions = { shell = "which actionlint >/dev/null 2>&1 && actionlint || (echo 'actionlint not found. Install with: brew install actionlint' && exit 1)", help = "Lint GitHub Actions workflows" }
 lock = { cmd = "uv lock", help = "Lock dependencies." }
 mypy = { cmd = "uv run mypy connector_builder_mcp", help = "Type check code with mypy" }
 test = { cmd = "uv run pytest tests/ -v", help = "Run tests with verbose output" }

--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -8,7 +8,7 @@ format = { cmd = "uv run ruff format .", help = "Format code with ruff" }
 format-check = { cmd = "uv run ruff format --check .", help = "Format check with ruff" }
 lint = { cmd = "uv run ruff check .", help = "Lint code with ruff" }
 lint-fix = { cmd = "uv run ruff check --fix .", help = "Lint and fix code with ruff" }
-check-gh-actions = { cmd = "actionlint", help = "Lint GitHub Actions workflows" }
+check-gh-actions = { cmd = "actionlint", help = "Lint GitHub Actions workflows (requires: go install github.com/rhymond/actionlint/cmd/actionlint@latest)" }
 lock = { cmd = "uv lock", help = "Lock dependencies." }
 mypy = { cmd = "uv run mypy connector_builder_mcp", help = "Type check code with mypy" }
 test = { cmd = "uv run pytest tests/ -v", help = "Run tests with verbose output" }

--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -8,7 +8,11 @@ format = { cmd = "uv run ruff format .", help = "Format code with ruff" }
 format-check = { cmd = "uv run ruff format --check .", help = "Format check with ruff" }
 lint = { cmd = "uv run ruff check .", help = "Lint code with ruff" }
 lint-fix = { cmd = "uv run ruff check --fix .", help = "Lint and fix code with ruff" }
-check-gh-actions = { shell = "which actionlint >/dev/null 2>&1 && actionlint || (echo 'ERROR: actionlint not found. Install with: brew install actionlint' && exit 1)", help = "Lint GitHub Actions workflows" }
+check-gh-actions.shell = """
+which actionlint >/dev/null 2>&1 && actionlint || \
+(echo "ERROR: actionlint not found. Install with: 'brew install actionlint'" && exit 1)
+"""
+check-gh-actions.help = "Lint GitHub Actions workflows"
 lock = { cmd = "uv lock", help = "Lock dependencies." }
 mypy = { cmd = "uv run mypy connector_builder_mcp", help = "Type check code with mypy" }
 test = { cmd = "uv run pytest tests/ -v", help = "Run tests with verbose output" }

--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -8,7 +8,7 @@ format = { cmd = "uv run ruff format .", help = "Format code with ruff" }
 format-check = { cmd = "uv run ruff format --check .", help = "Format check with ruff" }
 lint = { cmd = "uv run ruff check .", help = "Lint code with ruff" }
 lint-fix = { cmd = "uv run ruff check --fix .", help = "Lint and fix code with ruff" }
-check-gh-actions = { shell = "which actionlint >/dev/null 2>&1 && actionlint || (echo 'actionlint not found. Install with: brew install actionlint' && exit 1)", help = "Lint GitHub Actions workflows" }
+check-gh-actions = { shell = "which actionlint >/dev/null 2>&1 && actionlint || (echo 'ERROR: actionlint not found. Install with: brew install actionlint' && exit 1)", help = "Lint GitHub Actions workflows" }
 lock = { cmd = "uv lock", help = "Lock dependencies." }
 mypy = { cmd = "uv run mypy connector_builder_mcp", help = "Type check code with mypy" }
 test = { cmd = "uv run pytest tests/ -v", help = "Run tests with verbose output" }


### PR DESCRIPTION
# feat: Add check-gh-actions poe task for actionlint CLI

## Summary
Adds a new `check-gh-actions` poe task that runs actionlint CLI to lint GitHub Actions workflows locally. This complements the recently merged actionlint GitHub Actions workflow by providing a way for developers to check workflows before pushing changes.

The task is added to the development tasks section in `poe_tasks.toml` with installation instructions included in the help text.

## Review & Testing Checklist for Human
- [ ] **Test actionlint installation**: Verify the installation command works: `go install github.com/rhymond/actionlint/cmd/actionlint@latest`
- [ ] **Test the poe task**: Run `poe check-gh-actions` after installation to ensure it works correctly on existing workflows
- [ ] **Verify workflow linting**: Check that actionlint properly detects issues in GitHub Actions workflows (if any exist)

### Notes
- The task was not tested locally due to network restrictions preventing actionlint installation
- Users will need Go installed to use the provided installation command
- This task provides local linting capability to complement the GitHub Actions workflow that was recently implemented

---
**Link to Devin run**: https://app.devin.ai/sessions/064c9d5b289f41539aa6e5f6acfbb8cf  
**Requested by**: @aaronsteers