### PR TITLE
fix: return raw responses when requested even with 0 records

### DIFF
--- a/connector_builder_mcp/validation_testing.py
+++ b/connector_builder_mcp/validation_testing.py
@@ -419,11 +419,16 @@ def execute_stream_test_read(  # noqa: PLR0914
         execution_logs.extend(log for log in logs if "ERROR" not in str(log))
 
     if success is False:
+        raw_responses_data = None
+        if include_raw_responses_data is True:
+            raw_responses_data = slices
+
         return StreamTestResult(
             success=success,
             message=error_msgs[0] if error_msgs else "Unknown error occurred.",
             errors=error_msgs,
             logs=execution_logs,
+            raw_api_responses=raw_responses_data,
         )
 
     records_data: list[dict[str, Any]] = []
@@ -434,7 +439,7 @@ def execute_stream_test_read(  # noqa: PLR0914
                     records_data.extend(page.pop("records"))
 
     raw_responses_data = None
-    if include_raw_responses_data is True and slices:
+    if include_raw_responses_data is True:
         raw_responses_data = slices
 
     record_stats = None


### PR DESCRIPTION
# fix: return raw responses when requested even with 0 records

## Summary
Fixes a bug in `execute_stream_test_read` where `include_raw_responses_data: true` returned `null` instead of raw API responses when no records were found (e.g., `max_records=0`).

The issue occurred because:
1. When `max_records=0`, the function would fail with "No API output returned" and return early without processing raw responses
2. The successful path had a condition `if include_raw_responses_data is True and slices:` that prevented raw responses from being returned when `slices` was empty

**Changes made:**
- Added raw response handling to the early return path when `success=False`
- Removed the `and slices` condition so raw responses are returned whenever explicitly requested
- Raw responses now return empty list `[]` instead of `null` when no data is available but responses were requested

## Review & Testing Checklist for Human
- [ ] **Verify the original bug is fixed**: Test with `max_records=0` and `include_raw_responses_data=true` to confirm raw responses are returned (not null)
- [ ] **Test edge cases**: Try different failure scenarios (invalid manifests, network errors, etc.) with raw responses enabled to ensure the early return path works correctly
- [ ] **Check API contract compatibility**: Verify that existing callers can handle the new `raw_api_responses` field in failed responses without breaking
- [ ] **Test successful scenarios**: Confirm that removing the `and slices` condition doesn't cause issues when slices is legitimately empty in successful operations

### Notes
- The fix addresses both the early return path (when stream test fails) and the successful path (when stream test succeeds but has empty slices)
- All existing tests pass, but manual testing of the specific reported scenario is recommended
- Session requested by AJ Steers (@aaronsteers)
- Link to Devin run: https://app.devin.ai/sessions/98be4b20044e45f390a6036aa29f995b