### PR TITLE
fix: make evals work with standalone phoenix client package

### DIFF
--- a/connector_builder_agents/src/evals/dataset.py
+++ b/connector_builder_agents/src/evals/dataset.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import pandas as pd
 import yaml
 from phoenix.client import Client
-from phoenix.experiments.types import Dataset
+from phoenix.client.experiments import Dataset
 
 
 logger = logging.getLogger(__name__)

--- a/connector_builder_agents/src/evals/phoenix_run.py
+++ b/connector_builder_agents/src/evals/phoenix_run.py
@@ -15,11 +15,12 @@ Requirements:
     - Phoenix collector endpoint (PHOENIX_COLLECTOR_ENDPOINT in a local '.env')
 """
 
+import asyncio
 import logging
 import uuid
 
 from dotenv import load_dotenv
-from phoenix.experiments import run_experiment
+from phoenix.client import AsyncClient
 from phoenix.otel import register
 
 from .dataset import get_or_create_phoenix_dataset
@@ -36,37 +37,41 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 
 
-logger.info("Registering Phoenix tracer")
-register(
-    auto_instrument=True,
-)
-
-
-logger.info("Getting Phoenix dataset")
-dataset = get_or_create_phoenix_dataset()
-
-experiment_id = str(uuid.uuid4())[:5]
-experiment_name = f"builder-evals-{experiment_id}"
-evaluators = [readiness_eval, streams_eval]
-
-logger.info(f"Using evaluators: {[eval.__name__ for eval in evaluators]}")
-
-
-try:
-    logger.info(f"Starting experiment: {experiment_name}")
-    experiment = run_experiment(
-        dataset,
-        task=run_connector_build_task,
-        evaluators=evaluators,
-        experiment_name=experiment_name,
-        experiment_metadata={
-            "developer_model": EVAL_DEVELOPER_MODEL,
-            "manager_model": EVAL_MANAGER_MODEL,
-            "readiness_eval_model": READINESS_EVAL_MODEL,
-        },
-        timeout=1800,
+async def main():
+    logger.info("Registering Phoenix tracer")
+    register(
+        auto_instrument=True,
     )
-    logger.info(f"Experiment '{experiment_name}' completed successfully")
-except Exception as e:
-    logger.error(f"Experiment '{experiment_name}' failed: {e}")
-    raise
+
+    logger.info("Getting Phoenix dataset")
+    dataset = get_or_create_phoenix_dataset()
+
+    experiment_id = str(uuid.uuid4())[:5]
+    experiment_name = f"builder-evals-{experiment_id}"
+    evaluators = [readiness_eval, streams_eval]
+
+    logger.info(f"Using evaluators: {[eval.__name__ for eval in evaluators]}")
+
+    try:
+        client = AsyncClient()
+        logger.info(f"Starting experiment: {experiment_name}")
+        await client.experiments.run_experiment(
+            dataset=dataset,
+            task=run_connector_build_task,
+            evaluators=evaluators,
+            experiment_name=experiment_name,
+            experiment_metadata={
+                "developer_model": EVAL_DEVELOPER_MODEL,
+                "manager_model": EVAL_MANAGER_MODEL,
+                "readiness_eval_model": READINESS_EVAL_MODEL,
+            },
+            timeout=1800,
+        )
+        logger.info(f"Experiment '{experiment_name}' completed successfully")
+    except Exception as e:
+        logger.error(f"Experiment '{experiment_name}' failed: {e}")
+        raise
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
At somepoint i moved from the `phoenix` package, which is huge and contains the full platform, to the standalone packages we need (phoenix-client, phoenix-otel, phoenix-evals)

When I made the package switch, things broke due to slightly different behavior on the phoenix-client package. I didn't notice since locally the old package was still installed. 

This updates the syntax to work with the standalone client.