### PR TITLE
Restructure evals YAML to use input/expected top-level keys

### DIFF
--- a/connector_builder_agents/src/evals/data/connectors.yaml
+++ b/connector_builder_agents/src/evals/data/connectors.yaml
@@ -1,25 +1,31 @@
 connectors:
-  - name: "source-jsonplaceholder"
-    prompt_name: "JSONPlaceholder"
-    expected_streams:
-      - "posts"
-      - "comments"
-      - "albums"
-      - "photos"
-      - "todos"
-      - "users"
-  - name: "source-starwars"
-    prompt_name: "StarWars API (https://swapi.info/)"
-    expected_streams:
-      - "people"
-      - "films"
-      - "planets"
-      - "species"
-      - "starships"
-      - "vehicles"
-  - name: "source-rickandmorty"
-    prompt_name: "Rick and Morty API"
-    expected_streams:
-      - "characters"
-      - "episodes"
-      - "locations"
+  - input:
+      name: "source-jsonplaceholder"
+      prompt_name: "JSONPlaceholder"
+    expected:
+      expected_streams:
+        - "posts"
+        - "comments"
+        - "albums"
+        - "photos"
+        - "todos"
+        - "users"
+  - input:
+      name: "source-starwars"
+      prompt_name: "StarWars API (https://swapi.info/)"
+    expected:
+      expected_streams:
+        - "people"
+        - "films"
+        - "planets"
+        - "species"
+        - "starships"
+        - "vehicles"
+  - input:
+      name: "source-rickandmorty"
+      prompt_name: "Rick and Morty API"
+    expected:
+      expected_streams:
+        - "characters"
+        - "episodes"
+        - "locations"

--- a/connector_builder_agents/src/evals/dataset.py
+++ b/connector_builder_agents/src/evals/dataset.py
@@ -49,7 +49,8 @@ def get_dataset_with_hash(connectors: list[str] | None = None) -> tuple[pd.DataF
             filtered_config = {"connectors": df.to_dict("records")}
             hash_value = hashlib.sha256(yaml.safe_dump(filtered_config).encode()).hexdigest()[:8]
 
-            df["expected_streams"] = df["expected_streams"].apply(json.dumps)
+            df["input"] = df["input"].apply(json.dumps)
+            df["expected"] = df["expected"].apply(json.dumps)
 
             logger.info(
                 f"Successfully loaded evals dataset with {len(df)} connectors (hash: {hash_value})"
@@ -86,6 +87,6 @@ def get_or_create_phoenix_dataset(connectors: list[str] | None = None) -> Datase
         return px_client.datasets.create_dataset(
             name=dataset_name,
             dataframe=dataframe,
-            input_keys=["name", "prompt_name"],
-            output_keys=["expected_streams"],
+            input_keys=["input"],
+            output_keys=["expected"],
         )

--- a/connector_builder_agents/src/evals/evaluators.py
+++ b/connector_builder_agents/src/evals/evaluators.py
@@ -75,8 +75,8 @@ def streams_eval(expected: dict, output: dict) -> float:
     available_stream_names = [stream.get("name", "") for stream in available_streams]
     logger.info(f"Available stream names: {available_stream_names}")
 
-    # Get expected streams from the input (dataset row)
-    expected_stream_names = json.loads(expected.get("expected_streams", []))
+    expected_obj = json.loads(expected.get("expected", "{}"))
+    expected_stream_names = expected_obj.get("expected_streams", [])
     logger.info(f"Expected stream names: {expected_stream_names}")
 
     # Set attributes on span for visibility

--- a/connector_builder_agents/src/evals/summary.py
+++ b/connector_builder_agents/src/evals/summary.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 Airbyte, Inc., all rights reserved.
 """Generate markdown summaries of evaluation results."""
 
+import json
 import logging
 import os
 from collections import defaultdict
@@ -115,8 +116,10 @@ def extract_scores_by_connector(experiment: dict, client) -> dict:
             for record in json_data:
                 example_id = record.get("example_id")
                 input_data = record.get("input", {})
-                example_data_map[example_id] = input_data.get(
-                    "name", input_data.get("prompt_name", example_id)
+                input_json_str = input_data.get("input", "{}")
+                input_obj = json.loads(input_json_str)
+                example_data_map[example_id] = input_obj.get(
+                    "name", input_obj.get("prompt_name", example_id)
                 )
         except Exception as e:
             logger.warning(f"Failed to fetch connector names: {e}")
@@ -545,9 +548,11 @@ def generate_markdown_summary(experiment: dict, experiment_name: str) -> str | N
         for record in json_data:
             example_id = record.get("example_id")
             input_data = record.get("input", {})
+            input_json_str = input_data.get("input", "{}")
+            input_obj = json.loads(input_json_str)
             example_data_map[example_id] = {
-                "name": input_data.get("name", input_data.get("prompt_name", example_id)),
-                "input": input_data,
+                "name": input_obj.get("name", input_obj.get("prompt_name", example_id)),
+                "input": input_obj,
             }
     except Exception as e:
         logger.warning(f"Failed to fetch JSON data for input details: {e}")
@@ -564,8 +569,10 @@ def generate_markdown_summary(experiment: dict, experiment_name: str) -> str | N
         else:
             # Fallback to trying input from task run
             input_data = run.get("input", {})
-            connector_name = input_data.get(
-                "name", input_data.get("prompt_name", example_id or run_id)
+            input_json_str = input_data.get("input", "{}")
+            input_obj = json.loads(input_json_str)
+            connector_name = input_obj.get(
+                "name", input_obj.get("prompt_name", example_id or run_id)
             )
 
         # Calculate execution time

--- a/connector_builder_agents/src/evals/task.py
+++ b/connector_builder_agents/src/evals/task.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2025 Airbyte, Inc., all rights reserved.
 
+import json
 import logging
 import time
 
@@ -15,8 +16,9 @@ EVAL_MANAGER_MODEL = DEFAULT_MANAGER_MODEL
 
 
 async def run_connector_build_task(dataset_row: dict) -> dict:
-    connector_name = dataset_row.get("name", "unknown")
-    prompt_name = dataset_row.get("prompt_name", "unknown")
+    input_obj = json.loads(dataset_row.get("input", "{}"))
+    connector_name = input_obj.get("name", "unknown")
+    prompt_name = input_obj.get("prompt_name", "unknown")
     session_id = f"eval-{connector_name}-{int(time.time())}"
 
     logger.info(


### PR DESCRIPTION
# Restructure evals YAML to use input/expected top-level keys

## Summary

Restructures the connector evaluation YAML configuration to use a nested structure with top-level `input` and `expected` keys instead of flat fields. This change improves data organization and follows a more structured approach for evaluation datasets.

**Key Changes:**
- **YAML Structure**: Moved `name` and `prompt_name` into `input` object, `expected_streams` into `expected` object
- **Dataset Logic**: Updated Phoenix dataset to use `["input"]` as input_keys and `["expected"]` as output_keys
- **Serialization**: Both `input` and `expected` objects are now JSON-serialized in the dataset (following existing `expected_streams` pattern)
- **Consumers**: Updated evaluators, task runner, and summary generator to deserialize JSON objects

## Review & Testing Checklist for Human

- [ ] **Test end-to-end evaluation workflow** - Run a complete evaluation to ensure the restructured data flows correctly through dataset → task → evaluator → summary
- [ ] **Verify Phoenix dataset compatibility** - Confirm that existing evaluation experiments/datasets aren't broken by the input_keys/output_keys change
- [ ] **Test error handling** - Verify that malformed JSON in the YAML doesn't crash the system (defensive parsing with `json.loads(data.get("input", "{}"))`)

### Notes

This change follows the existing pattern used for `expected_streams` serialization/deserialization. All existing tests pass, but since there are no specific unit tests for the evals module, manual end-to-end testing is recommended to ensure the evaluation pipeline works correctly with the new data structure.

**Link to Devin run**: https://app.devin.ai/sessions/ea974f8b0409467a97d8a12bac71d35e
**Requested by**: @pedroslopez